### PR TITLE
Feat/date label UI #16

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.0.0",
     "@tsconfig/strictest": "^2.0.1",
+    "@types/date-fns": "^2.6.0",
     "@types/jest": "^29.5.4",
     "@types/node": "20.8.10",
     "@types/react": "18.2.30",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.4.3",
+    "date-fns": "^2.30.0",
     "lucide-react": "^0.288.0",
     "next": "13.5.6",
     "react": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@tanstack/react-query':
     specifier: ^5.4.3
     version: 5.4.3(react-dom@18.2.0)(react@18.2.0)
+  date-fns:
+    specifier: ^2.30.0
+    version: 2.30.0
   lucide-react:
     specifier: ^0.288.0
     version: 0.288.0(react@18.2.0)
@@ -8049,6 +8052,13 @@ packages:
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
     dev: true
+
+  /date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
+    engines: {node: '>=0.11'}
+    dependencies:
+      '@babel/runtime': 7.23.2
+    dev: false
 
   /dayjs@1.11.10:
     resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ devDependencies:
   '@tsconfig/strictest':
     specifier: ^2.0.1
     version: 2.0.2
+  '@types/date-fns':
+    specifier: ^2.6.0
+    version: 2.6.0
   '@types/jest':
     specifier: ^29.5.4
     version: 29.5.6
@@ -5536,6 +5539,13 @@ packages:
     resolution: {integrity: sha512-w2id4lNf2DzAAQ+A3bD9QTY/qpCw9rYlci9RbBscEmF5RO3U/acrcCErvsqkoIZqz9n0yv4CVUqz/6DKDOEZnw==}
     dev: true
 
+  /@types/date-fns@2.6.0:
+    resolution: {integrity: sha512-9DSw2ZRzV0Tmpa6PHHJbMcZn79HHus+BBBohcOaDzkK/G3zMjDUDYjJIWBFLbkh+1+/IOS0A59BpQfdr37hASg==}
+    deprecated: This is a stub types definition for date-fns (https://github.com/date-fns/date-fns). date-fns provides its own type definitions, so you don't need @types/date-fns installed!
+    dependencies:
+      date-fns: 2.30.0
+    dev: true
+
   /@types/debug@4.1.10:
     resolution: {integrity: sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==}
     dependencies:
@@ -8058,7 +8068,6 @@ packages:
     engines: {node: '>=0.11'}
     dependencies:
       '@babel/runtime': 7.23.2
-    dev: false
 
   /dayjs@1.11.10:
     resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}

--- a/src/components/ui/DateLabel/index.stories.tsx
+++ b/src/components/ui/DateLabel/index.stories.tsx
@@ -1,0 +1,35 @@
+import { DateLabel } from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof DateLabel> = {
+  component: DateLabel,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DateLabel>;
+
+export const Default: Story = {
+  args: {
+    date: '2023-01-01T00:00:00',
+  },
+};
+
+export const FullDate: Story = {
+  args: {
+    date: '2023-01-01T00:00:00',
+    format: 'yyyy/MM/dd',
+  },
+};
+
+export const Date: Story = {
+  args: {
+    date: '2023-01-01T00:00:00',
+    format: 'MM/dd',
+  },
+};

--- a/src/components/ui/DateLabel/index.test.tsx
+++ b/src/components/ui/DateLabel/index.test.tsx
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react';
+
+import '@testing-library/jest-dom';
+import { DateLabel } from '.';
+
+describe('ui/DateLabelのテスト', () => {
+  const testDate = '2023-01-01T00:00:00';
+  const isoString = new Date(testDate).toISOString();
+  it('renders the component with default date format', () => {
+    const screen = render(<DateLabel date={testDate} />);
+    const timeElement = screen.getByText(/2023\/01\/01 00:00:00/);
+    expect(timeElement).toBeInTheDocument();
+    expect(timeElement).toHaveAttribute('dateTime', isoString);
+  });
+
+  it('renders the component with custom date format', () => {
+    const customFormat = 'yyyy-MM-dd';
+    const screen = render(<DateLabel date={testDate} format={customFormat} />);
+    const timeElement = screen.getByText(/2023-01-01/);
+    expect(timeElement).toBeInTheDocument();
+    expect(timeElement).toHaveAttribute('dateTime', isoString);
+  });
+
+  it('applies custom class names', () => {
+    const customClassName = 'custom-class';
+    const screen = render(
+      <DateLabel date={testDate} className={customClassName} />
+    );
+    const timeElement = screen.getByText(/2023\/01\/01 00:00:00/);
+    expect(timeElement).toHaveClass(customClassName);
+  });
+
+  it('renders the correct dateTime attribute', () => {
+    const screen = render(<DateLabel date={testDate} />);
+    const timeElement = screen.getByText(/2023\/01\/01 00:00:00/);
+    expect(timeElement).toHaveAttribute('dateTime', isoString);
+  });
+});

--- a/src/components/ui/DateLabel/index.tsx
+++ b/src/components/ui/DateLabel/index.tsx
@@ -1,0 +1,18 @@
+import { dateFormat } from '@/libs/dateFormat';
+import { cn } from '@/libs/utils';
+
+type Props = {
+  date: string;
+  format?: string;
+  className?: string;
+};
+
+export const DateLabel: React.FC<Props> = ({
+  date,
+  format = 'yyyy/MM/dd HH:mm:ss',
+  className,
+}) => (
+  <time className={cn(className)} dateTime={new Date(date).toISOString()}>
+    {dateFormat(date, format)}
+  </time>
+);

--- a/src/libs/dateFormat/index.test.ts
+++ b/src/libs/dateFormat/index.test.ts
@@ -1,0 +1,35 @@
+import { dateFormat } from '.';
+
+describe('dateFormat function', () => {
+  it('formats the date correctly according to the given format', () => {
+    const date = '2023-01-01T00:00:00.000Z';
+    const formatString = 'yyyy-MM-dd';
+    const result = dateFormat(date, formatString);
+    expect(result).toBe('2023-01-01');
+  });
+
+  it('throws an error with invalid date object', () => {
+    const invalidDate = 'not a real date';
+    const formatString = 'yyyy-MM-dd';
+    expect(() => dateFormat(invalidDate, formatString)).toThrowError();
+  });
+
+  it('throws an error with invalid date format', () => {
+    const date = '2023-01-01T00:00:00.000Z';
+    const invalidFormatString = '';
+    expect(() => dateFormat(date, invalidFormatString)).toThrowError();
+  });
+
+  it('handles incorrect format strings', () => {
+    const date = '2023-01-01T00:00:00.000Z';
+    const formatString = 'not a format';
+    expect(() => dateFormat(date, formatString)).toThrowError();
+  });
+
+  it('formats the date correctly in a specific locale', () => {
+    const date = '2023-01-01T00:00:00.000Z';
+    const formatString = 'PPP';
+    const result = dateFormat(date, formatString);
+    expect(result).toBe('January 1st, 2023');
+  });
+});

--- a/src/libs/dateFormat/index.ts
+++ b/src/libs/dateFormat/index.ts
@@ -1,0 +1,4 @@
+import { format } from 'date-fns';
+
+export const dateFormat = (dateString: string, _format: string): string =>
+  format(new Date(dateString), _format);


### PR DESCRIPTION
## issue番号

closes #16 

## 変更点概要
dateStringをtimeタグに変換するuiコンポーネントを作成

## 参考文献(あれば)

## スクリーンショット(必要であれば)
<img width="1055" alt="スクリーンショット 2023-11-03 2 14 11" src="https://github.com/Kyutech-C3/ToyBox_front_replace/assets/94045195/3bb73277-6438-49a0-beaf-265a19811def">

## チェック項目

- [x] テストが通ったか
- [x] ビルドが通ったか
- [x] `self assign`したか
- [x] レビュー優先度のラベルをつけたか
