### PR TITLE
Feat/full screen #28

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "next": "13.5.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-error-boundary": "^4.0.11"
+    "react-error-boundary": "^4.0.11",
+    "react-full-screen": "^1.1.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   react-error-boundary:
     specifier: ^4.0.11
     version: 4.0.11(react@18.2.0)
+  react-full-screen:
+    specifier: ^1.1.1
+    version: 1.1.1(react@18.2.0)
 
 devDependencies:
   '@commitlint/cli':
@@ -9630,6 +9633,10 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
+  /fscreen@1.2.0:
+    resolution: {integrity: sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg==}
+    dev: false
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -13539,6 +13546,16 @@ packages:
       react: '>=16.13.1'
     dependencies:
       '@babel/runtime': 7.23.2
+      react: 18.2.0
+    dev: false
+
+  /react-full-screen@1.1.1(react@18.2.0):
+    resolution: {integrity: sha512-xoEgkoTiN0dw9cjYYGViiMCBYbkS97BYb4bHPhQVWXj1UnOs8PZ1rPzpX+2HMhuvQV1jA5AF9GaRbO3fA5aZtg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>= 16.8.0'
+    dependencies:
+      fscreen: 1.2.0
       react: 18.2.0
     dev: false
 

--- a/src/components/functional/FullScreen/hook.ts
+++ b/src/components/functional/FullScreen/hook.ts
@@ -1,0 +1,19 @@
+import { useFullScreenHandle } from 'react-full-screen';
+
+import type { FullScreenHandle } from 'react-full-screen';
+
+type IUseFullScreen = {
+  handle: FullScreenHandle;
+  handleClick: () => void;
+};
+export const useFullScreen = (): IUseFullScreen => {
+  const handle = useFullScreenHandle();
+  const handleClick = (): void => {
+    if (handle.active) {
+      handle.exit().catch((e) => console.log(e));
+    } else {
+      handle.enter().catch((e) => console.log(e));
+    }
+  };
+  return { handle, handleClick };
+};

--- a/src/components/functional/FullScreen/index.stories.tsx
+++ b/src/components/functional/FullScreen/index.stories.tsx
@@ -1,0 +1,32 @@
+import Image from 'next/image';
+
+import { FullScreen } from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof FullScreen> = {
+  component: FullScreen,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FullScreen>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-96 h-96">
+      <FullScreen>
+        <Image
+          src="https://avatars.githubusercontent.com/u/94045195?v=4"
+          alt="icon"
+          fill
+          objectFit="contain"
+        />
+      </FullScreen>
+    </div>
+  ),
+};

--- a/src/components/functional/FullScreen/index.test.tsx
+++ b/src/components/functional/FullScreen/index.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import '@testing-library/jest-dom';
@@ -61,7 +59,7 @@ describe('functional/FullScreen', () => {
     );
 
     expect(screen.getByRole('button')).toHaveClass(
-      'absolute right-0 bottom-0 p-2'
+      'absolute right-0 bottom-0 p-2 z-50'
     );
   });
 });

--- a/src/components/functional/FullScreen/index.test.tsx
+++ b/src/components/functional/FullScreen/index.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import '@testing-library/jest-dom';
+import { useFullScreen } from './hook';
+
+import { FullScreen } from '.';
+
+jest.mock('./hook', () => ({
+  useFullScreen: jest.fn(),
+}));
+
+describe('functional/FullScreen', () => {
+  const handle = {
+    active: false,
+    enter: jest.fn(),
+    exit: jest.fn(),
+  };
+  const handleClick = jest.fn();
+
+  beforeEach(() => {
+    (useFullScreen as jest.Mock).mockImplementation(() => ({
+      handle,
+      handleClick,
+    }));
+  });
+
+  test('renders children and a Maximize button when not active', () => {
+    render(
+      <FullScreen>
+        <div>Test Content</div>
+      </FullScreen>
+    );
+
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+
+    expect(screen.getByRole('button')).toHaveClass(
+      'absolute right-0 bottom-0 z-50'
+    );
+  });
+
+  test('calls handleClick when the Maximize button is clicked', () => {
+    render(
+      <FullScreen>
+        <div>Test Content</div>
+      </FullScreen>
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders a Minimize button when active', () => {
+    handle.active = true;
+    render(
+      <FullScreen>
+        <div>Test Content</div>
+      </FullScreen>
+    );
+
+    expect(screen.getByRole('button')).toHaveClass(
+      'absolute right-0 bottom-0 p-2'
+    );
+  });
+});

--- a/src/components/functional/FullScreen/index.tsx
+++ b/src/components/functional/FullScreen/index.tsx
@@ -1,0 +1,42 @@
+type Props = {
+  children: ReactNode;
+};
+import type { ReactNode } from 'react';
+
+import { Maximize, Minimize } from 'lucide-react';
+import { FullScreen as ReactFullScreen } from 'react-full-screen';
+
+import { useFullScreen } from './hook';
+
+export const FullScreen: React.FC<Props> = ({ children }) => {
+  const { handle, handleClick } = useFullScreen();
+  return (
+    <div className="relative select-none h-full w-full">
+      {!handle.active && (
+        <button
+          onClick={handleClick}
+          className="absolute right-0 bottom-0 z-50"
+        >
+          <Maximize
+            className="dark:text-black text-white shadow-black drop-shadow"
+            size={36}
+          />
+        </button>
+      )}
+      <ReactFullScreen handle={handle} className="relative h-full w-full">
+        {children}
+        {handle.active && (
+          <button
+            onClick={handleClick}
+            className="absolute right-0 bottom-0 p-2"
+          >
+            <Minimize
+              className="dark:text-black text-white shadow-black drop-shadow"
+              size={36}
+            />
+          </button>
+        )}
+      </ReactFullScreen>
+    </div>
+  );
+};

--- a/src/components/functional/FullScreen/index.tsx
+++ b/src/components/functional/FullScreen/index.tsx
@@ -1,41 +1,35 @@
-type Props = {
-  children: ReactNode;
-};
 import type { ReactNode } from 'react';
 
 import { Maximize, Minimize } from 'lucide-react';
 import { FullScreen as ReactFullScreen } from 'react-full-screen';
 
 import { useFullScreen } from './hook';
+type Props = {
+  children: ReactNode;
+};
 
 export const FullScreen: React.FC<Props> = ({ children }) => {
   const { handle, handleClick } = useFullScreen();
   return (
     <div className="relative select-none h-full w-full">
-      {!handle.active && (
-        <button
-          onClick={handleClick}
-          className="absolute right-0 bottom-0 z-50"
-        >
-          <Maximize
-            className="dark:text-black text-white shadow-black drop-shadow"
-            size={36}
-          />
-        </button>
-      )}
       <ReactFullScreen handle={handle} className="relative h-full w-full">
         {children}
-        {handle.active && (
-          <button
-            onClick={handleClick}
-            className="absolute right-0 bottom-0 p-2"
-          >
+        <button
+          onClick={handleClick}
+          className="absolute right-0 bottom-0 p-2 z-50"
+        >
+          {handle.active ? (
             <Minimize
               className="dark:text-black text-white shadow-black drop-shadow"
               size={36}
             />
-          </button>
-        )}
+          ) : (
+            <Maximize
+              className="dark:text-black text-white shadow-black drop-shadow"
+              size={36}
+            />
+          )}
+        </button>
       </ReactFullScreen>
     </div>
   );


### PR DESCRIPTION
## issue番号

closes #28 

## 変更点概要
フルスクリーンを提供するコンポーネントを作成

## 参考文献(あれば)

## スクリーンショット(必要であれば)
<img width="404" alt="スクリーンショット 2023-11-03 16 06 00" src="https://github.com/Kyutech-C3/ToyBox_front_replace/assets/94045195/c31ff3c4-7ea5-4493-ac9d-4c38310c2128">

## チェック項目

- [x] テストが通ったか
- [x] ビルドが通ったか
- [x] `self assign`したか
- [x] レビュー優先度のラベルをつけたか
