### PR TITLE
Chore/dependabot config #58

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,11 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
-      time: "12:00"
-      timezone: "Asia/Tokyo"
-    target-branch: "develop"
+      interval: 'weekly'
+    target-branch: 'develop'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Enable auto-merge for Dependabot PRs
+        if: contains(steps.metadata.outputs.dependency-names, 'my-dependency') && steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## issue番号

closes #58 

## 変更点概要
- 依存関係のアップデート頻度を毎日から毎週に変更
- github actionsのversionのアップデートを新たに追加
- パッチバージョンのアップデートであれば自動的にマージするようにworkflowを追加

ブランチプロテクションがあるため自動マージが有効でない可能性がある。

## 参考文献(あれば)
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
## スクリーンショット(必要であれば)

## チェック項目

- [x] テストが通ったか
- [x] ビルドが通ったか
- [x] `self assign`したか
- [x] レビュー優先度のラベルをつけたか
