### PR TITLE
chore: chromatic deploy work only not dependent PR

### DIFF
--- a/.github/workflows/chromatic_deploy.yml
+++ b/.github/workflows/chromatic_deploy.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
-
+    if: !contains(github.event.head_commit.message , 'dependabot')
     steps:
       - uses: actions/checkout@v1
       - name: Install dependencies


### PR DESCRIPTION
## issue番号

closes #62

## 変更点概要
chromaticのデプロイをdependabotが関わっていない場合に限り実行するように変更

## 参考文献(あれば)

## スクリーンショット(必要であれば)

## チェック項目

- [x] テストが通ったか
- [x] ビルドが通ったか
- [x] `self assign`したか
- [x] レビュー優先度のラベルをつけたか
