### PR TITLE
feat: add accordion ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@commitlint/config-conventional": "^17.7.0",
     "@markuplint/jsx-parser": "^3.11.0",
     "@markuplint/react-spec": "^3.12.0",
+    "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tooltip": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ devDependencies:
   '@markuplint/react-spec':
     specifier: ^3.12.0
     version: 3.12.0(@markuplint/ml-core@3.14.0)
+  '@radix-ui/react-accordion':
+    specifier: ^1.1.2
+    version: 1.1.2(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-avatar':
     specifier: ^1.0.4
     version: 1.0.4(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
@@ -3102,6 +3105,35 @@ packages:
       '@babel/runtime': 7.23.2
     dev: true
 
+  /@radix-ui/react-accordion@1.1.2(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-fDG7jcoNKVjSK6yfmuAs0EnPDro0WMXIhMtXdTBWqEioVW206ku+4Lw07e+13lUkFkpoEQ2PdeMIAGpdqEAmDg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collapsible': 1.0.3(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@types/react': 18.2.30
+      '@types/react-dom': 18.2.13
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: true
+
   /@radix-ui/react-arrow@1.0.3(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==}
     peerDependencies:
@@ -3140,6 +3172,34 @@ packages:
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.30)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@types/react': 18.2.30
+      '@types/react-dom': 18.2.13
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: true
+
+  /@radix-ui/react-collapsible@1.0.3(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-UBmVDkmR6IvDsloHVN+3rtx4Mi5TFvylYXpluuv0f37dtaz3H99bp8No0LGXRigVpl3UAT4l9j6bIchh42S/Gg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.30)(react@18.2.0)
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.30)(react@18.2.0)
       '@types/react': 18.2.30
       '@types/react-dom': 18.2.13

--- a/src/components/ui/Accordion/index.stories.tsx
+++ b/src/components/ui/Accordion/index.stories.tsx
@@ -7,57 +7,105 @@ import {
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-const meta: Meta<typeof Accordion> = {
+type AccordionPropsAndCustomArgs = React.ComponentProps<typeof Accordion> & {
+  type: 'single' | 'multiple';
+};
+
+const meta: Meta<AccordionPropsAndCustomArgs> = {
   component: Accordion,
   parameters: {
     layout: 'centered',
   },
   tags: ['autodocs'],
+  argTypes: {
+    type: {
+      options: ['single', 'multiple'],
+      control: { type: 'radio' },
+      description:
+        'Determines whether one or multiple items can be opened at the same time.',
+      defaultValue: 'single',
+    },
+  },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof Accordion>;
+type Story = StoryObj<AccordionPropsAndCustomArgs>;
 
 export const Default: Story = {
-  render: () => (
-    <Accordion type="single" collapsible>
-      <AccordionItem value="item-1">
-        <AccordionTrigger>Accordion Trigger</AccordionTrigger>
-        <AccordionContent>Accordion content</AccordionContent>
-      </AccordionItem>
-    </Accordion>
+  args: {
+    type: 'single',
+  },
+  render: (args: AccordionPropsAndCustomArgs) => (
+    <div className="w-96">
+      <Accordion type={args.type} collapsible className="w-full">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Accordion Trigger 1</AccordionTrigger>
+          <AccordionContent>Accordion content 1</AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-2">
+          <AccordionTrigger>Accordion Trigger 2</AccordionTrigger>
+          <AccordionContent>Accordion content 2</AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </div>
   ),
 };
 
-export const MultipleItems: Story = {
+export const TypeSingle: Story = {
   render: () => (
-    <Accordion type="single" collapsible>
-      <AccordionItem value="item-1">
-        <AccordionTrigger>Accordion Trigger 1</AccordionTrigger>
-        <AccordionContent>Accordion content 1</AccordionContent>
-      </AccordionItem>
-      <AccordionItem value="item-2">
-        <AccordionTrigger>Accordion Trigger 2</AccordionTrigger>
-        <AccordionContent>Accordion content 2</AccordionContent>
-      </AccordionItem>
-      <AccordionItem value="item-3">
-        <AccordionTrigger>Accordion Trigger 3</AccordionTrigger>
-        <AccordionContent>Accordion content 3</AccordionContent>
-      </AccordionItem>
-    </Accordion>
+    <div className="w-96">
+      <Accordion type="single" collapsible className="w-full">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Accordion Trigger 1</AccordionTrigger>
+          <AccordionContent>Accordion content 1</AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-2">
+          <AccordionTrigger>Accordion Trigger 2</AccordionTrigger>
+          <AccordionContent>Accordion content 2</AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-3">
+          <AccordionTrigger>Accordion Trigger 3</AccordionTrigger>
+          <AccordionContent>Accordion content 3</AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </div>
+  ),
+};
+
+export const TypeMultiple: Story = {
+  render: () => (
+    <div className="w-96">
+      <Accordion type="multiple" className="w-full">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Accordion Trigger 1</AccordionTrigger>
+          <AccordionContent>Accordion content 1</AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-2">
+          <AccordionTrigger>Accordion Trigger 2</AccordionTrigger>
+          <AccordionContent>Accordion content 2</AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-3">
+          <AccordionTrigger>Accordion Trigger 3</AccordionTrigger>
+          <AccordionContent>Accordion content 3</AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </div>
   ),
 };
 
 export const LongContent: Story = {
   render: () => (
-    <Accordion type="single" collapsible>
-      <AccordionItem value="item-1">
-        <AccordionTrigger>Accordion Trigger</AccordionTrigger>
-        <AccordionContent>
-          This is a very long accordion content for checking the animation
-        </AccordionContent>
-      </AccordionItem>
-    </Accordion>
+    <div className="w-96">
+      <Accordion type="single" collapsible className="w-full">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Accordion Trigger</AccordionTrigger>
+          <AccordionContent>
+            This is a very long accordion content for checking whether the
+            content will be in multiple lines or not.
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </div>
   ),
 };

--- a/src/components/ui/Accordion/index.stories.tsx
+++ b/src/components/ui/Accordion/index.stories.tsx
@@ -1,0 +1,63 @@
+import {
+  Accordion,
+  AccordionItem,
+  AccordionContent,
+  AccordionTrigger,
+} from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Accordion> = {
+  component: Accordion,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Accordion>;
+
+export const Default: Story = {
+  render: () => (
+    <Accordion type="single" collapsible>
+      <AccordionItem value="item-1">
+        <AccordionTrigger>Accordion Trigger</AccordionTrigger>
+        <AccordionContent>Accordion content</AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  ),
+};
+
+export const MultipleItems: Story = {
+  render: () => (
+    <Accordion type="single" collapsible>
+      <AccordionItem value="item-1">
+        <AccordionTrigger>Accordion Trigger 1</AccordionTrigger>
+        <AccordionContent>Accordion content 1</AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-2">
+        <AccordionTrigger>Accordion Trigger 2</AccordionTrigger>
+        <AccordionContent>Accordion content 2</AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-3">
+        <AccordionTrigger>Accordion Trigger 3</AccordionTrigger>
+        <AccordionContent>Accordion content 3</AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  ),
+};
+
+export const LongContent: Story = {
+  render: () => (
+    <Accordion type="single" collapsible>
+      <AccordionItem value="item-1">
+        <AccordionTrigger>Accordion Trigger</AccordionTrigger>
+        <AccordionContent>
+          This is a very long accordion content for checking the animation
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  ),
+};

--- a/src/components/ui/Accordion/index.test.tsx
+++ b/src/components/ui/Accordion/index.test.tsx
@@ -1,0 +1,72 @@
+import { render } from '@testing-library/react';
+
+import '@testing-library/jest-dom';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from '.';
+
+describe('ui/Accordion', () => {
+  it('renders trigger text correctly', () => {
+    const triggerText = 'Trigger';
+    const screen = render(
+      <Accordion type="single" collapsible>
+        <AccordionItem value="item-1">
+          <AccordionTrigger>{triggerText}</AccordionTrigger>
+          <AccordionContent>Content</AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    );
+
+    expect(screen.getByText(triggerText)).toBeInTheDocument();
+  });
+
+  it('renders content text correctly', () => {
+    const contentText = 'Content';
+    const screen = render(
+      <Accordion type="single" collapsible defaultValue="item-1">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Trigger</AccordionTrigger>
+          <AccordionContent>{contentText}</AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    );
+
+    expect(screen.getByText(contentText)).toBeInTheDocument();
+  });
+
+  it('accordion is closed default', () => {
+    const contentText = 'Content';
+    const screen = render(
+      <Accordion type="single" collapsible>
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Trigger</AccordionTrigger>
+          <AccordionContent>{contentText}</AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    );
+
+    expect(() => screen.getByText(contentText)).toThrow();
+  });
+
+  it('renders components with correct classes', () => {
+    const triggerText = 'Trigger';
+    const contentText = 'Content';
+
+    const screen = render(
+      <Accordion type="single" collapsible defaultValue="item-1">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>{triggerText}</AccordionTrigger>
+          <AccordionContent>{contentText}</AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    );
+
+    expect(screen.getByText(triggerText)).toHaveClass(
+      'flex flex-1 items-center justify-between py-4 font-medium transition-all'
+    );
+    expect(screen.getByText(contentText)).toHaveClass('pb-4 pt-0');
+  });
+});

--- a/src/components/ui/Accordion/index.test.tsx
+++ b/src/components/ui/Accordion/index.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import '@testing-library/jest-dom';
 import {
@@ -37,20 +38,6 @@ describe('ui/Accordion', () => {
     expect(screen.getByText(contentText)).toBeInTheDocument();
   });
 
-  it('accordion is closed default', () => {
-    const contentText = 'Content';
-    const screen = render(
-      <Accordion type="single" collapsible>
-        <AccordionItem value="item-1">
-          <AccordionTrigger>Trigger</AccordionTrigger>
-          <AccordionContent>{contentText}</AccordionContent>
-        </AccordionItem>
-      </Accordion>
-    );
-
-    expect(() => screen.getByText(contentText)).toThrow();
-  });
-
   it('renders components with correct classes', () => {
     const triggerText = 'Trigger';
     const contentText = 'Content';
@@ -68,5 +55,50 @@ describe('ui/Accordion', () => {
       'flex flex-1 items-center justify-between py-4 font-medium transition-all'
     );
     expect(screen.getByText(contentText)).toHaveClass('pb-4 pt-0');
+  });
+
+  it('accordion works correctly by clicking', async () => {
+    const trigger1 = 'Trigger 1';
+    const trigger2 = 'Trigger 2';
+    const content1 = 'Content 1';
+    const content2 = 'Content 2';
+
+    const screen = render(
+      <Accordion type="single" collapsible>
+        <AccordionItem value="item-1">
+          <AccordionTrigger>{trigger1}</AccordionTrigger>
+          <AccordionContent>{content1}</AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-2">
+          <AccordionTrigger>{trigger2}</AccordionTrigger>
+          <AccordionContent>{content2}</AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    );
+
+    // closed by default
+    expect(() => screen.getByText(content1)).toThrow();
+    expect(() => screen.getByText(content2)).toThrow();
+
+    // open first item
+    await userEvent.click(screen.getByText(trigger1));
+
+    // first item is open, second is closed
+    expect(screen.getByText(content1)).toBeInTheDocument();
+    expect(() => screen.getByText(content2)).toThrow();
+
+    // open second item
+    await userEvent.click(screen.getByText(trigger2));
+
+    // first item is closed, second is open
+    expect(() => screen.getByText(content1)).toThrow();
+    expect(screen.getByText(content2)).toBeInTheDocument();
+
+    // close second item
+    await userEvent.click(screen.getByText(trigger2));
+
+    // both items are closed
+    expect(() => screen.getByText(content1)).toThrow();
+    expect(() => screen.getByText(content2)).toThrow();
   });
 });

--- a/src/components/ui/Accordion/index.tsx
+++ b/src/components/ui/Accordion/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { forwardRef } from 'react';
+import type { ElementRef, ComponentPropsWithoutRef } from 'react';
 
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { ChevronDown } from 'lucide-react';
@@ -10,8 +11,8 @@ import { cn } from '@/libs/utils';
 const Accordion = AccordionPrimitive.Root;
 
 const AccordionItem = forwardRef<
-  React.ElementRef<typeof AccordionPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+  ElementRef<typeof AccordionPrimitive.Item>,
+  ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
 >(({ className, ...props }, ref) => (
   <AccordionPrimitive.Item
     ref={ref}
@@ -22,8 +23,8 @@ const AccordionItem = forwardRef<
 AccordionItem.displayName = 'AccordionItem';
 
 const AccordionTrigger = forwardRef<
-  React.ElementRef<typeof AccordionPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+  ElementRef<typeof AccordionPrimitive.Trigger>,
+  ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
 >(({ className, children, ...props }, ref) => (
   <AccordionPrimitive.Header className="flex">
     <AccordionPrimitive.Trigger
@@ -42,8 +43,8 @@ const AccordionTrigger = forwardRef<
 AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
 
 const AccordionContent = forwardRef<
-  React.ElementRef<typeof AccordionPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+  ElementRef<typeof AccordionPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
   <AccordionPrimitive.Content
     ref={ref}

--- a/src/components/ui/Accordion/index.tsx
+++ b/src/components/ui/Accordion/index.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { forwardRef } from 'react';
+
+import * as AccordionPrimitive from '@radix-ui/react-accordion';
+import { ChevronDown } from 'lucide-react';
+
+import { cn } from '@/libs/utils';
+
+const Accordion = AccordionPrimitive.Root;
+
+const AccordionItem = forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn('border-b', className)}
+    {...props}
+  />
+));
+AccordionItem.displayName = 'AccordionItem';
+
+const AccordionTrigger = forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        'flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+));
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
+
+const AccordionContent = forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className={cn(
+      'overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down',
+      className
+    )}
+    {...props}
+  >
+    <div className="pb-4 pt-0">{children}</div>
+  </AccordionPrimitive.Content>
+));
+AccordionContent.displayName = AccordionPrimitive.Content.displayName;
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };


### PR DESCRIPTION
## issue番号

closes #82 

## 変更点概要
Accordion UI を作成しました

## 参考文献(あれば)
https://ui.shadcn.com/docs/components/accordion

## スクリーンショット(必要であれば)
<img width="150" alt="image" src="https://github.com/Kyutech-C3/ToyBox_front_replace/assets/37594486/05234796-4bfd-4580-bc92-3a68e259c599">
<img width="159" alt="image" src="https://github.com/Kyutech-C3/ToyBox_front_replace/assets/37594486/ab07ac9d-a7f3-4fdf-994d-1d1feaabe66b">

## チェック項目

- [X] テストが通ったか
- [X] ビルドが通ったか
- [X] `self assign`したか
- [X] レビュー優先度のラベルをつけたか
