### PR TITLE
feat: add modal (dialog) ui ( #84 )

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@markuplint/react-spec": "^3.12.0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-avatar": "^1.0.4",
+    "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tooltip": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ devDependencies:
   '@radix-ui/react-avatar':
     specifier: ^1.0.4
     version: 1.0.4(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
+  '@radix-ui/react-dialog':
+    specifier: ^1.0.5
+    version: 1.0.5(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-popover':
     specifier: ^1.0.7
     version: 1.0.7(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
@@ -3260,6 +3263,40 @@ packages:
       '@babel/runtime': 7.23.2
       '@types/react': 18.2.30
       react: 18.2.0
+    dev: true
+
+  /@radix-ui/react-dialog@1.0.5(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.4(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.13)(@types/react@18.2.30)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.30)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.30)(react@18.2.0)
+      '@types/react': 18.2.30
+      '@types/react-dom': 18.2.13
+      aria-hidden: 1.2.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.5.5(@types/react@18.2.30)(react@18.2.0)
     dev: true
 
   /@radix-ui/react-direction@1.0.1(@types/react@18.2.30)(react@18.2.0):

--- a/src/components/ui/Dialog/index.stories.tsx
+++ b/src/components/ui/Dialog/index.stories.tsx
@@ -1,0 +1,100 @@
+import { Button } from '../Button';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+type DialogPropsAndCustomArgs = React.ComponentProps<typeof Dialog> & {
+  modal?: boolean;
+  defaultOpen?: boolean;
+};
+
+const meta: Meta<DialogPropsAndCustomArgs> = {
+  component: Dialog,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    modal: {
+      control: { type: 'boolean' },
+      defaultValue: true,
+      description:
+        'The modality of the dialog. When set to true, interaction with outside elements will be disabled and only dialog content will be visible to screen readers.',
+    },
+    defaultOpen: {
+      control: { type: 'boolean' },
+      defaultValue: false,
+      description:
+        'The open state of the dialog when it is initially rendered. Use when you do not need to control its open state.',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<DialogPropsAndCustomArgs>;
+
+export const Default: Story = {
+  args: {
+    modal: true,
+  },
+  render: (args) => (
+    <Dialog modal={args.modal || false} defaultOpen={args.defaultOpen || false}>
+      <DialogTrigger asChild>
+        <Button>Open</Button>
+      </DialogTrigger>
+      <DialogContent className="bg-primary text-primary-foreground">
+        <DialogHeader>
+          <DialogTitle>Dialog Title</DialogTitle>
+          <DialogDescription>Dialog Description</DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  ),
+};
+
+export const Modal: Story = {
+  args: {
+    modal: true,
+  },
+  render: (args) => (
+    <Dialog modal={args.modal || false} defaultOpen={args.defaultOpen || false}>
+      <DialogTrigger asChild>
+        <Button>Open</Button>
+      </DialogTrigger>
+      <DialogContent className="bg-primary text-primary-foreground">
+        <DialogHeader>
+          <DialogTitle>Dialog Title</DialogTitle>
+          <DialogDescription>Dialog Description</DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  ),
+};
+
+export const NotModal: Story = {
+  args: {
+    modal: false,
+  },
+  render: (args) => (
+    <Dialog modal={args.modal || false} defaultOpen={args.defaultOpen || false}>
+      <DialogTrigger asChild>
+        <Button>Open</Button>
+      </DialogTrigger>
+      <DialogContent className="bg-primary text-primary-foreground">
+        <DialogHeader>
+          <DialogTitle>Dialog Title</DialogTitle>
+          <DialogDescription>Dialog Description</DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  ),
+};

--- a/src/components/ui/Dialog/index.test.tsx
+++ b/src/components/ui/Dialog/index.test.tsx
@@ -1,0 +1,70 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import '@testing-library/jest-dom';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '.';
+
+describe('ui/Dialog', () => {
+  it('renders content correctly', () => {
+    const header = 'Header';
+    const title = 'Title';
+    const description = 'Description';
+
+    const screen = render(
+      <Dialog modal open>
+        <DialogTrigger>Trigger</DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            {header}
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    );
+
+    expect(screen.getByText(header)).toHaveClass(
+      'flex flex-col space-y-1.5 text-center sm:text-left'
+    );
+
+    expect(screen.getByText(title)).toHaveClass(
+      'text-lg font-semibold leading-none tracking-tight'
+    );
+
+    expect(screen.getByText(description)).toHaveClass(
+      'text-sm text-muted-foreground'
+    );
+  });
+
+  it('opens correctly', async () => {
+    const trigger = 'Trigger';
+    const content = 'Content';
+
+    const screen = render(
+      <Dialog modal>
+        <DialogTrigger>{trigger}</DialogTrigger>
+        <DialogContent className="bg-primary text-primary-foreground">
+          <DialogHeader>
+            <DialogTitle>Dialog Title</DialogTitle>
+            <DialogDescription>{content}</DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    );
+
+    // closed by default
+    expect(() => screen.getByText(content)).toThrow();
+
+    // open on trigger clicked
+    await userEvent.click(screen.getByText(trigger));
+    expect(screen.getByText(content)).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/Dialog/index.test.tsx
+++ b/src/components/ui/Dialog/index.test.tsx
@@ -51,7 +51,7 @@ describe('ui/Dialog', () => {
     const screen = render(
       <Dialog modal>
         <DialogTrigger>{trigger}</DialogTrigger>
-        <DialogContent className="bg-primary text-primary-foreground">
+        <DialogContent>
           <DialogHeader>
             <DialogTitle>Dialog Title</DialogTitle>
             <DialogDescription>{content}</DialogDescription>

--- a/src/components/ui/Dialog/index.tsx
+++ b/src/components/ui/Dialog/index.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { forwardRef } from 'react';
+import type {
+  ElementRef,
+  ComponentPropsWithoutRef,
+  HTMLAttributes,
+} from 'react';
+
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+
+import { cn } from '@/libs/utils';
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = forwardRef<
+  ElementRef<typeof DialogPrimitive.Overlay>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = forwardRef<
+  ElementRef<typeof DialogPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>): JSX.Element => (
+  <div
+    className={cn(
+      'flex flex-col space-y-1.5 text-center sm:text-left',
+      className
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>): JSX.Element => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = forwardRef<
+  ElementRef<typeof DialogPrimitive.Title>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      'text-lg font-semibold leading-none tracking-tight',
+      className
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = forwardRef<
+  ElementRef<typeof DialogPrimitive.Description>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};


### PR DESCRIPTION
## issue番号
closes #84 

## 変更点概要
Modal (Dialog) コンポーネントを作成しました

## 参考文献(あれば)
https://ui.shadcn.com/docs/components/dialog

## スクリーンショット(必要であれば)
![image](https://github.com/Kyutech-C3/ToyBox_front_replace/assets/37594486/00c933d2-0a1a-4d37-94f1-41b2b168d5e0)

## チェック項目

- [X] テストが通ったか
- [X] ビルドが通ったか
- [X] `self assign`したか
- [X] レビュー優先度のラベルをつけたか
